### PR TITLE
Fix docker image for backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,18 +1,16 @@
-FROM python:3.13-slim-bookworm
+# Use official uv image that already includes Python + uv
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 # Set working directory inside container
 WORKDIR /app/backend
 
-# Copy only files needed for installing dependencies
+# Copy only project manifests first (helps with layer caching)
 COPY pyproject.toml uv.lock* ./
 
-# Install dependencies with uv into .venv
-RUN pip install --upgrade pip uv \
-    && uv sync --project .
-
-# Add the venv's bin directory to PATH so that `python` and `uvicorn` from .venv are used
+# Where the virtualenv will live (persisted via the named volume)
 ENV VENV_PATH=/app/backend/.venv
-ENV PATH="$VENV_PATH/bin:$PATH"
+# Make sure venv's bin is first on PATH (even before it exists)
+ENV PATH="${VENV_PATH}/bin:${PATH}"
 
 # Copy the rest of the backend code
 COPY . .
@@ -20,5 +18,6 @@ COPY . .
 # Expose backend port
 EXPOSE 8000
 
-# Run backend with autoreload (now using uvicorn from .venv)
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# On first run: if .venv is missing (fresh volume), install exactly what's in uv.lock;
+# then start the app using the venv via `uv run`.
+CMD ["/bin/sh", "-lc", "test -x \"$VENV_PATH/bin/python\" || uv sync --frozen; uv run uvicorn main:app --host 0.0.0.0 --port 8000 --reload"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,10 +6,13 @@ WORKDIR /app/backend
 # Copy only files needed for installing dependencies
 COPY pyproject.toml uv.lock* ./
 
-# Install dependencies with uv
-RUN pip install --upgrade pip && \
-    pip install uv uvicorn fastapi && \
-    uv sync --project .
+# Install dependencies with uv into .venv
+RUN pip install --upgrade pip uv \
+    && uv sync --project .
+
+# Add the venv's bin directory to PATH so that `python` and `uvicorn` from .venv are used
+ENV VENV_PATH=/app/backend/.venv
+ENV PATH="$VENV_PATH/bin:$PATH"
 
 # Copy the rest of the backend code
 COPY . .
@@ -17,5 +20,5 @@ COPY . .
 # Expose backend port
 EXPOSE 8000
 
-# Run backend with autoreload
+# Run backend with autoreload (now using uvicorn from .venv)
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,34 @@
 services:
   backend:
     build:
-      context: ./backend
+      context: ./backend # Use the Dockerfile in ./backend to build the backend image
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8000:8000" # Expose container port 8000 on host port 8000
     volumes:
+      # Mount your local backend code into the container for hot‐reload
       - ./backend:/app/backend
+      # Persist the Python virtualenv here so dependencies survive code mounts
+      - backend-venv:/app/backend/.venv
+    env_file:
+      - ./backend/.env
     environment:
-      - PYTHONUNBUFFERED=1
+      - PYTHONUNBUFFERED=1 # Disable Python output buffering for real‐time logs
 
   frontend:
     build:
-      context: ./frontend
+      context: ./frontend # Build the frontend image from ./frontend
       dockerfile: Dockerfile
     ports:
-      - "3000:3000"
+      - "3000:3000" # Expose container port 3000 on host port 3000
     volumes:
+      # Mount your local frontend code for hot‐reload
       - ./frontend:/app/frontend
-      - /app/frontend/node_modules
+      # Persist node_modules in a named volume to avoid host overwrites
+      - frontend-node-modules:/app/frontend/node_modules
     environment:
-      - NUXT_PUBLIC_API_BASE=http://backend:8000
+      - NUXT_PUBLIC_API_BASE=http://backend:8000 # Point Nuxt to the backend service
+
+volumes:
+  backend-venv: # Named volume to store Python .venv dependencies
+  frontend-node-modules: # Named volume to store node_modules dependencies


### PR DESCRIPTION
### **Changes in Docker files** 🐳 

_**Backend Dockerfile**_

Added:

- ENV VENV_PATH=/app/backend/.venv  
- ENV PATH="$VENV_PATH/bin:$PATH"

so that all python, uvicorn and other executables come from the virtualenv created by uv sync rather than the global interpreter.

_**docker-compose.yml**_

Switched from anonymous to named volumes for both Python and Node dependencies:
volumes:
  - backend-venv:/app/backend/.venv
  - frontend-node-modules:/app/frontend/node_modules
Added an env_file entry for the backend service to load POSTGRES_* variables from ./backend/.env automatically.


### Why

- Ensures that the container uses the virtualenv-installed dependencies (e.g. FastAPI, SQLModel) instead of any system-default Python.
- Keeps node_modules and .venv isolated in persistent, named volumes so they aren’t overwritten by bind-mounts.
- Automatically loads database credentials from .env .