### PR TITLE
Fix/husky setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,6 @@ services:
       - NUXT_INTERNAL_API_BASE=http://backend:8000
     # Ensure the dev server listens on all interfaces inside the container
     # so the host port mapping can reach it.
-    command: ["pnpm", "dev", "--host", "0.0.0.0"]
 
 volumes:
   backend-venv: # Named volume to store Python .venv dependencies

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm -C frontend lint-staged
+pnpm -C frontend lint-staged --relative

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,1 +1,18 @@
+# dependency locks
 pnpm-lock.yaml
+package-lock.json
+yarn.lock
+
+# deps
+node_modules
+
+# build / generated
+.nuxt
+.output
+dist
+coverage
+build
+.next
+
+# system
+.DS_Store

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,17 +1,19 @@
+
 FROM node:20
 
-# Set the working directory for the frontend
 WORKDIR /app/frontend
 
-# Install pnpm globally
-RUN npm install -g pnpm
+# Użyj corepack zamiast npm -g pnpm (stabilniej i wersjonowalnie)
+RUN corepack enable && corepack prepare pnpm@10.15.0 --activate
 
-# Copy dependency definitions from the current context (./frontend)
+# Manifesty osobno (cache warstw)
 COPY package.json pnpm-lock.yaml* ./
 
-# Copy the rest of the application source code from the current context
+# Reszta źródeł
 COPY . .
 
 EXPOSE 3000
 
-CMD ["pnpm", "dev"]
+# Jeśli brakuje node_modules -> zainstaluj; potem odpal dev na wszystkich interfejsach
+CMD ["/bin/sh","-lc","set -e; if [ ! -x node_modules/.bin/nuxt ]; then echo '→ Installing deps…'; pnpm install --frozen-lockfile; fi; exec pnpm dev"]
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,19 +1,17 @@
-
 FROM node:20
 
 WORKDIR /app/frontend
 
-# Użyj corepack zamiast npm -g pnpm (stabilniej i wersjonowalnie)
+# Use corepack instead of npm -g pnpm (more stable and versioned)
 RUN corepack enable && corepack prepare pnpm@10.15.0 --activate
 
-# Manifesty osobno (cache warstw)
+# Copy manifests separately (cache layers)
 COPY package.json pnpm-lock.yaml* ./
 
-# Reszta źródeł
+# Copy the rest of the sources
 COPY . .
 
 EXPOSE 3000
 
-# Jeśli brakuje node_modules -> zainstaluj; potem odpal dev na wszystkich interfejsach
+# If node_modules is missing -> install deps; then start dev on all interfaces
 CMD ["/bin/sh","-lc","set -e; if [ ! -x node_modules/.bin/nuxt ]; then echo '→ Installing deps…'; pnpm install --frozen-lockfile; fi; exec pnpm dev"]
-

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -3,6 +3,18 @@ import withNuxt from "./.nuxt/eslint.config.mjs";
 import eslintConfigPrettier from "eslint-config-prettier/flat";
 
 export default withNuxt({
+    ignores: [
+        "**/node_modules/**",
+        "**/.nuxt/**",
+        "**/.output/**",
+        "**/dist/**",
+        "**/coverage/**",
+        "**/.husky/**",
+        "**/.vscode/**",
+        "**/.idea/**",
+        "**/.DS_Store",
+        "**/pnpm-lock.yaml",
+    ],
     rules: {
         "no-else-return": 2,
     },

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -13,7 +13,6 @@ export default withNuxt({
         "**/.vscode/**",
         "**/.idea/**",
         "**/.DS_Store",
-        "**/pnpm-lock.yaml",
     ],
     rules: {
         "no-else-return": 2,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
     "type": "module",
     "scripts": {
         "build": "nuxt build",
-        "dev": "nuxt dev",
+        "dev": "nuxt dev --host 0.0.0.0",
         "generate": "nuxt generate",
         "preview": "nuxt preview",
         "postinstall": "nuxt prepare",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,18 +10,19 @@
         "postinstall": "nuxt prepare",
         "preinstall": "npx only-allow pnpm",
         "lint": "eslint .",
-        "lint:fix": "eslint . --fix",
+        "lint:fix": "eslint --fix .",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "prepare": "cd .. && husky frontend/.husky",
         "lint-staged": "lint-staged"
     },
     "lint-staged": {
-        "frontend/**/*.{js,ts,vue}": [
-            "pnpm -C frontend eslint --fix"
+        "**/*.{js,ts,vue}": [
+            "eslint --fix",
+            "prettier -w --"
         ],
-        "frontend/**/*.{css,scss,html,md,json}": [
-            "pnpm -C frontend prettier -w"
+        "**/*.{css,scss,html,md,json}": [
+            "prettier -w --"
         ]
     },
     "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,15 +14,14 @@
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "prepare": "cd .. && husky frontend/.husky",
-        "lint-staged": "cd .. && lint-staged"
+        "lint-staged": "lint-staged"
     },
     "lint-staged": {
-        "*.{js,ts,vue}": [
-            "pnpm -C frontend lint:fix",
-            "pnpm -C frontend format"
+        "frontend/**/*.{js,ts,vue}": [
+            "pnpm -C frontend eslint --fix"
         ],
-        "*.{css,scss,html,md,json}": [
-            "pnpm -C frontend format"
+        "frontend/**/*.{css,scss,html,md,json}": [
+            "pnpm -C frontend prettier -w"
         ]
     },
     "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
     "name": "nuxt-app",
     "private": true,
     "type": "module",
+    "packageManager": "pnpm@10.15.0",
     "scripts": {
         "build": "nuxt build",
         "dev": "nuxt dev --host 0.0.0.0",

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -11,6 +11,7 @@ const { data, error, status } = useApi<BackendResponse>("/users");
 <template>
     <div>
         <h1>Test połączenia z backendem</h1>
+        <h1>Test połączenia z backendem</h1>
         <div v-if="status === 'pending'">Ładowanie...</div>
         <div v-else-if="error">Błąd: {{ error }}</div>
         <div v-else>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -11,7 +11,7 @@ const { data, error, status } = useApi<BackendResponse>("/users");
 <template>
     <div>
         <h1>Test połączenia z backendem</h1>
-        <h1>Test połączenia z backendem</h1>
+
         <div v-if="status === 'pending'">Ładowanie...</div>
         <div v-else-if="error">Błąd: {{ error }}</div>
         <div v-else>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -11,7 +11,6 @@ const { data, error, status } = useApi<BackendResponse>("/users");
 <template>
     <div>
         <h1>Test połączenia z backendem</h1>
-
         <div v-if="status === 'pending'">Ładowanie...</div>
         <div v-else-if="error">Błąd: {{ error }}</div>
         <div v-else>


### PR DESCRIPTION
- Replace pre-commit command with pnpm -C frontend lint-staged --relative so lint-staged resolves paths relative to frontend/ (no more frontend/frontend/... issues).
- Simplify lint-staged tasks to operate only on staged files: eslint --fix and prettier -w -- (no . and no extra -C).
- Remove the brittle cd .. && lint-staged hack that ran from repo root and could pick up non-frontend files.
- Tighten glob patterns to target only frontend code (**/*.{js,ts,vue}, etc.) while keeping execution scoped to frontend/.
- Add explicit ignores in frontend/eslint.config.mjs (flat config): node_modules, .nuxt, .output, dist, coverage, IDE folders, lockfiles, etc.
- Expand .prettierignore with lockfiles, build outputs, and system files to prevent accidental formatting of generated artifacts.
- Run Prettier after ESLint for JS/TS/Vue, ensuring consistent style and deterministic auto-fixes.
- Result: faster, safer pre-commits confined to frontend/, no ENOENT/EPERM path errors, and cleaner, repeatable formatting/linting.